### PR TITLE
Add What Keeps Coming Back article draft

### DIFF
--- a/src/content/log/008-what-keeps-coming-back.md
+++ b/src/content/log/008-what-keeps-coming-back.md
@@ -1,0 +1,43 @@
+---
+number: 8
+type: "article"
+tag: "ARTICLE · SELF"
+title: "What Keeps Coming Back"
+description: "A short note on creative identity, recurring interests, and treating repeated curiosity as signal instead of noise."
+url: "/log/what-keeps-coming-back/"
+pubDate: 2026-06-22
+---
+
+I have a habit of treating creative interest like it should eventually settle down and pick a lane.
+
+Writing, drawing, game development, personal sites, piano, poetry, small apps. The list keeps changing, but the shape of the list has been pretty stable for a long time. I get pulled toward one outlet, start imagining what it could become, then feel the weight of how much work it would take to get good enough for the version in my head. Eventually another outlet starts to glow from the side of the room.
+
+For a long time, I read that as failure.
+
+If I were serious about writing, I would write consistently. If I were serious about drawing, I would draw consistently. If I were serious about game development, I would finish a game instead of circling the idea of being a person who makes games.
+
+There is truth in that. Finishing matters. Practice matters. There is no version of this where I get the full reward of craft without doing the boring middle part.
+
+But I think I have been flattening the pattern too much.
+
+The fact that an interest rotates out does not mean it was fake. The fact that it rotates back in might be the more important part.
+
+Some ideas disappear because they were just novelty. Others keep returning after years. Blogging shows up. Personal sites show up. Game ideas show up. Writing shows up. Drawing shows up. Tools for memory and follow-through show up. The specific project changes, but the same pressure keeps finding new surfaces.
+
+That is useful information.
+
+Maybe the question is not "which one of these am I really?" Maybe that is too heavy. Maybe the better question is "what keeps coming back, and what does it keep asking for?"
+
+Recurring interest is not a finished identity. It is not proof that I should quit everything and become a novelist, artist, indie hacker, or whatever label happens to feel alive that week. It is softer than that. It is evidence that some part of me still wants a place to make things, tell the truth in my own voice, and leave behind artifacts that feel like mine.
+
+That reframes the problem.
+
+Instead of trying to solve myself by choosing the perfect creative container, I can build smaller containers that survive rotation. A daily note. A log entry. A tiny app. A short poem. A half-page reflection. A sketch. Something modest enough that it does not need to become my whole identity before it is allowed to exist.
+
+The throughline may be less about finding the one correct outlet and more about keeping a working surface open.
+
+I do not want to confuse movement with progress. There is still a real risk in endlessly researching, collecting, and restarting. But the answer probably is not self-disgust. It is better instrumentation. Notice what returns. Notice what dies. Notice which ideas still have heat after the easy part wears off.
+
+Curiosity is noisy day to day. Over time, it becomes a map.
+
+I do not need every returning interest to become a life plan. I just need to stop dismissing the return itself.


### PR DESCRIPTION
## Draft

Self-insight article draft for The Log.

## Core idea

Recurring creative interests may be signal rather than failure: the important clue is what keeps returning over time.

## Log entry

- Tag: `ARTICLE · SELF`
- Title: `What Keeps Coming Back`
- Description: `A short note on creative identity, recurring interests, and treating repeated curiosity as signal instead of noise.`
- URL: `/log/what-keeps-coming-back/`

## Sources used

- `projects/Daily Self-Insight Posts for My Site.md` - workflow and purpose for Greyhaven-backed public drafts.
- `notes/I cannot find a creative outlet.md` - core recurring creative-outlet tension.
- `notes/rolling obsessions break long-term creative effort.md` - names the failure mode without making the draft only self-critical.
- `notes/interest tracking makes motivation visible over time.md` - reframes recurring curiosity as useful evidence.
- `notes/creative desire gets muddy when it is aimed at engagement.md` - helped keep the draft focused on the work itself, not external reaction.
- `journal/daily/2019-05-13.md` and `journal/daily/2021-01-06.md` - older public-safe evidence that blogging, creative identity, app dev, and game dev keep recurring.

## Voice notes

- First person, compact paragraphs, plain language.
- Avoided therapy voice and diagnosis.
- Kept private details out of the public post.

## Review questions

- Does this feel true?
- Does this sound like you?
- Is anything too personal or too bland for the site?
- Is `ARTICLE · SELF` the right tag, or should it be closer to `ARTICLE · NOTE`?

## Checks

- [x] `npm ci`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Verified generated homepage, RSS, and `/log/what-keeps-coming-back/` output contain the new entry.